### PR TITLE
Enable reply-to-clear (add AI-review comment triggers)

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -4,6 +4,11 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - 'main'
+  # reply-to-clear (acknowledge-to-clear): clear a non-critical finding by comment.
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
 jobs:
   review:
     uses: justlogincom/.github/.github/workflows/ai-pr-review.yml@main


### PR DESCRIPTION
Adds the two comment-event triggers to this repo's AI PR review wrapper so developers can clear a non-critical finding by commenting (reply-to-clear). Org-wide rollout; carries skip-ai-review (no review needed for a wrapper-only change). No-op unless ack_resolve_enabled is on.